### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A simple wrapper for the Tesseract OCR package for node.js
 ## Installation
 There is a hard dependency on the [Tesseract project](https://code.google.com/p/tesseract-ocr/).  You can find installation instructions for various platforms on the project site. For Homebrew users, the installation is quick and easy.
 
-    brew install tesseract --all-languages
+    brew install tesseract --with-all-languages
 
 The above will install all of the language packages available, if you don't need them all you can remove the `--all-languages` flag and install them manually, by downloading them to your local machine and then exposing the `TESSDATA_PREFIX` variable into your path:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple wrapper for the Tesseract OCR package for node.js
 * Tesseract 3.01 or higher is needed for this to work
 
 ## Installation
-There is a hard dependency on the [Tesseract project](https://code.google.com/p/tesseract-ocr/).  You can find installation instructions for various platforms on the project site. For Homebrew users, the installation is quick and easy.
+There is a hard dependency on the [Tesseract project](https://github.com/tesseract-ocr/tesseract).  You can find installation instructions for various platforms on the project site. For Homebrew users, the installation is quick and easy.
 
     brew install tesseract --all-languages
 

--- a/lib/tesseract.js
+++ b/lib/tesseract.js
@@ -7,7 +7,7 @@ var utils = require('./utils');
 var exec = require('child_process').exec;
 var fs = require('fs');
 var tmpdir = require('os').tmpdir(); // let the os take care of removing zombie tmp files
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var path = require('path');
 var glob = require("glob");
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "glob": "^5.0.10",
-    "node-uuid": "^1.4.1"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "~1.16.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.